### PR TITLE
feat: add conditional validation for local Weaviate configurations

### DIFF
--- a/app/components/configuration/SettingComponents.tsx
+++ b/app/components/configuration/SettingComponents.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+
 import React from "react";
 import { IoAdd } from "react-icons/io5";
 
@@ -84,3 +86,12 @@ export const SettingTitle: React.FC<SettingTitleProps> = ({
     </div>
   );
 };
+
+//switch button
+export const SettingSwitch: React.FC<{
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}> = ({ checked, onChange }) => {
+  return <Checkbox checked={checked} onCheckedChange={onChange} className="data-[state=checked]:bg-accent data-[state=checked]:text-primary" />;
+};
+

--- a/app/components/configuration/SettingInput.tsx
+++ b/app/components/configuration/SettingInput.tsx
@@ -13,6 +13,7 @@ interface SettingInputProps<T extends string | number> {
   value: T;
   onChange: (value: T) => void;
   isInvalid?: boolean;
+  disabled?: boolean;
 }
 
 const SettingInput = <T extends string | number>({
@@ -20,6 +21,7 @@ const SettingInput = <T extends string | number>({
   value,
   onChange,
   isInvalid = false,
+  disabled = false,
 }: SettingInputProps<T>) => {
   const [visible, setVisible] = useState(isProtected);
 
@@ -48,9 +50,11 @@ const SettingInput = <T extends string | number>({
         type={inputType}
         value={value.toString()}
         onChange={(e) => handleChange(e.target.value)}
+        disabled={disabled}
         className={cn(
           isInvalid &&
-            "border-warning ring-warning/20 focus-visible:ring-warning"
+            "border-warning ring-warning/20 focus-visible:ring-warning",
+          disabled && "opacity-50 cursor-not-allowed"
         )}
       />
       {!isNumberType && (
@@ -58,6 +62,7 @@ const SettingInput = <T extends string | number>({
           variant="ghost"
           className="h-8 w-8 text-secondary flex-shrink-0"
           onClick={() => setVisible(!visible)}
+          disabled={disabled}
         >
           {visible ? <IoMdEye /> : <IoMdEyeOff />}
         </Button>

--- a/app/components/configuration/hooks/useConfigValidation.ts
+++ b/app/components/configuration/hooks/useConfigValidation.ts
@@ -27,9 +27,11 @@ export function useConfigValidation(
       };
     }
 
+    const isWeaviateLocal = currentUserConfig.settings?.WEAVIATE_IS_LOCAL as boolean;
+
     return {
       wcd_url: Boolean(currentUserConfig.settings.WCD_URL?.trim()),
-      wcd_api_key: Boolean(currentUserConfig.settings.WCD_API_KEY?.trim()),
+      wcd_api_key: isWeaviateLocal ? true : Boolean(currentUserConfig.settings.WCD_API_KEY?.trim()),
       base_provider: Boolean(currentUserConfig.settings.BASE_PROVIDER?.trim()),
       base_model: Boolean(currentUserConfig.settings.BASE_MODEL?.trim()),
       complex_provider: Boolean(
@@ -97,10 +99,12 @@ export function useConfigValidation(
       currentFrontendConfig?.save_trees_to_weaviate;
 
     if (needsStorageValidation) {
+      const isStorageLocal = currentFrontendConfig?.save_location_wcd_url?.trim() === "http://localhost:8080";
+      
       if (!currentFrontendConfig?.save_location_wcd_url?.trim()) {
         issues.push("Storage URL required when saving is enabled");
       }
-      if (!currentFrontendConfig?.save_location_wcd_api_key?.trim()) {
+      if (!isStorageLocal && !currentFrontendConfig?.save_location_wcd_api_key?.trim()) {
         issues.push("Storage API Key required when saving is enabled");
       }
     }
@@ -124,8 +128,12 @@ export function useConfigValidation(
   // Helper functions to get warning issues for each section
   const getWeaviateIssues = () => {
     const issues: string[] = [];
+    const isWeaviateLocal = currentUserConfig?.settings?.WEAVIATE_IS_LOCAL as boolean;
+    
     if (!currentValidation.wcd_url) issues.push("Weaviate Cluster URL");
-    if (!currentValidation.wcd_api_key) issues.push("Weaviate API Key");
+    if (!isWeaviateLocal && !Boolean(currentUserConfig?.settings?.WCD_API_KEY?.trim())) {
+      issues.push("Weaviate API Key");
+    }
     return issues;
   };
 

--- a/app/components/configuration/sections/StorageSection.tsx
+++ b/app/components/configuration/sections/StorageSection.tsx
@@ -9,6 +9,7 @@ import {
   SettingCard,
   SettingGroup,
   SettingItem,
+  SettingSwitch,
   SettingTitle,
 } from "../SettingComponents";
 import SettingInput from "../SettingInput";
@@ -36,6 +37,8 @@ export default function StorageSection({
   onUpdateFrontend,
   onCopyWeaviateValues,
 }: StorageSectionProps) {
+  const isLocal = currentFrontendConfig?.save_location_wcd_url?.trim() === "http://localhost:8080";
+
   return (
     <SettingCard>
       <div className="flex flex-col sm:flex-row items-start sm:items-center w-full justify-between gap-3">
@@ -87,6 +90,18 @@ export default function StorageSection({
       )}
 
       <SettingGroup>
+      <SettingItem>
+          <SettingTitle
+            title="Weaviate Is Local"
+            description="Whether the Weaviate cluster is local."
+          />
+          <SettingSwitch
+            checked={isLocal}
+            onChange={(value) => {
+              onUpdateFrontend("save_location_wcd_url", value ? "http://localhost:8080" : "");
+            }}
+          />
+          </SettingItem>
         <SettingItem>
           <SettingTitle
             title="URL"
@@ -120,6 +135,7 @@ export default function StorageSection({
               onUpdateFrontend("save_location_wcd_api_key", value);
             }}
             isInvalid={
+              !isLocal &&
               (currentFrontendConfig?.save_configs_to_weaviate ||
                 currentFrontendConfig?.save_trees_to_weaviate) &&
               !currentFrontendConfig?.save_location_wcd_api_key?.trim()

--- a/app/components/configuration/sections/WeaviateSection.tsx
+++ b/app/components/configuration/sections/WeaviateSection.tsx
@@ -9,6 +9,7 @@ import {
   SettingGroup,
   SettingItem,
   SettingTitle,
+  SettingSwitch,
 } from "../SettingComponents";
 import SettingInput from "../SettingInput";
 import WarningCard from "../WarningCard";
@@ -39,6 +40,8 @@ export default function WeaviateSection({
   onUpdateSettings,
   onUpdateFrontend,
 }: WeaviateSectionProps) {
+  const isLocal = currentUserConfig?.settings.WEAVIATE_IS_LOCAL as boolean;
+
   return (
     <SettingCard>
       <SettingHeader
@@ -60,7 +63,21 @@ export default function WeaviateSection({
         />
       )}
 
+    
+
       <SettingGroup>
+       <SettingItem>
+          <SettingTitle
+            title="Weaviate Is Local"
+            description="Whether the Weaviate cluster is local."
+          />
+          <SettingSwitch
+            checked={isLocal}
+            onChange={(value) => {
+              onUpdateSettings("WEAVIATE_IS_LOCAL", value);
+            }}
+          />
+          </SettingItem>
         <SettingItem>
           <SettingTitle
             title="URL"
@@ -78,6 +95,36 @@ export default function WeaviateSection({
 
         <SettingItem>
           <SettingTitle
+            title="Local Weaviate GRPC Port"
+            description="The port of the local Weaviate cluster."
+          />
+          <SettingInput
+            isProtected={false}
+            value={currentUserConfig?.settings.LOCAL_WEAVIATE_GRPC_PORT || 0}
+            onChange={(value) => {
+              onUpdateSettings("LOCAL_WEAVIATE_GRPC_PORT", value);
+            }}
+            disabled={!isLocal}
+          />
+        </SettingItem>
+        <SettingItem>
+          <SettingTitle
+            title="Local Weaviate Port"
+            description="The port of the local Weaviate cluster."
+          />
+          <SettingInput
+            isProtected={false}
+            value={currentUserConfig?.settings.LOCAL_WEAVIATE_PORT || 0}
+            onChange={(value) => {
+              onUpdateSettings("LOCAL_WEAVIATE_PORT", value);
+            }}
+            disabled={!isLocal}
+          />
+        </SettingItem>
+        
+
+        <SettingItem>
+          <SettingTitle
             title="API Key"
             description="The API key of your Weaviate cluster."
           />
@@ -87,7 +134,7 @@ export default function WeaviateSection({
             onChange={(value) => {
               onUpdateSettings("WCD_API_KEY", value);
             }}
-            isInvalid={!wcdApiKeyValid}
+            isInvalid={!isLocal && !wcdApiKeyValid}
           />
         </SettingItem>
 

--- a/app/components/configuration/utils/configUtils.ts
+++ b/app/components/configuration/utils/configUtils.ts
@@ -21,16 +21,18 @@ export function shouldHighlightUseSameCluster(
   if (!isSavingEnabled) return false;
 
   // Check if Weaviate cluster fields are filled
+  const isWeaviateLocal = currentUserConfig.settings?.WEAVIATE_IS_LOCAL as boolean;
   const weaviateHasUrl = Boolean(currentUserConfig.settings.WCD_URL?.trim());
-  const weaviateHasApiKey = Boolean(
+  const weaviateHasApiKey = isWeaviateLocal || Boolean(
     currentUserConfig.settings.WCD_API_KEY?.trim()
   );
   const weaviateFieldsFilled = weaviateHasUrl && weaviateHasApiKey;
 
   // Check if storage fields are missing
+  const isStorageLocal = currentFrontendConfig.save_location_wcd_url?.trim() === "http://localhost:8080";
   const storageUrlMissing =
     !currentFrontendConfig.save_location_wcd_url?.trim();
-  const storageApiKeyMissing =
+  const storageApiKeyMissing = !isStorageLocal &&
     !currentFrontendConfig.save_location_wcd_api_key?.trim();
   const storageFieldsMissing = storageUrlMissing || storageApiKeyMissing;
 

--- a/app/types/objects.ts
+++ b/app/types/objects.ts
@@ -142,6 +142,9 @@ export type Settings = {
   USE_FEEDBACK: boolean;
   WCD_API_KEY: string;
   WCD_URL: string;
+  WEAVIATE_IS_LOCAL: boolean;
+  LOCAL_WEAVIATE_GRPC_PORT: number;
+  LOCAL_WEAVIATE_PORT: number;
 };
 
 // For PATCHing collection metadata (matches backend schema)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elysia",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elysia",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^4.6.2",
         "@floating-ui/react": "^0.27.12",


### PR DESCRIPTION

<img width="1641" height="1359" alt="localweaviate" src="https://github.com/user-attachments/assets/e1f76b05-ade0-4785-be9d-e865eac2cf44" />

This PR is related to Elysia Backend: https://github.com/weaviate/elysia/pull/26

- Make API key validation conditional based on WEAVIATE_IS_LOCAL setting
- Add disabled state support to SettingInput component
- Update WeaviateSection to disable port fields when not local
- Update StorageSection API key validation for local configurations
- Fix null safety issues in validation hooks and utilities

This allows users to configure local Weaviate instances without requiring API keys while maintaining validation for remote configurations.