### PR TITLE
Added automatic notification Github actions workflow on release

### DIFF
--- a/.github/workflows/notify-backend.yml
+++ b/.github/workflows/notify-backend.yml
@@ -1,0 +1,20 @@
+name: Notify on Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: dannyjameswilliams/elysia-testing
+          event-type: frontend-release
+          client-payload: |
+            {
+              "release_tag": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}"
+            }

--- a/.github/workflows/notify-backend.yml
+++ b/.github/workflows/notify-backend.yml
@@ -11,7 +11,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
-          repository: dannyjameswilliams/elysia-testing
+          repository: weaviate/elysia
           event-type: frontend-release
           client-payload: |
             {


### PR DESCRIPTION
Added a github actions workflow that notifies the backend of a new frontend release.

When a release is _published_ from a tag on the frontend, this triggers the repository dispatch workflow so that the backend repository `weaviate/elysia` can see new releases, and create a PR and deploy the latest frontend.

It checks for releases of the format `vA.B.C` where `A`, `B`, `C` are integers, and creates the PR to the `release/vA.B.X` branch of `weaviate/elysia`